### PR TITLE
feature: use age toolchain from masmovil/bazel-rules feature/enable-sops-with-age

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,14 +9,19 @@ http_archive(
     url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.35.0/bazel-lib-v1.35.0.tar.gz",
 )
 
-# Masmovil 2023-04-18 release
-http_archive(
+## Masmovil 2023-04-18 release
+#http_archive(
+#    name = "com_github_masmovil_bazel_rules",
+#    sha256 = "9c8ac4c60da1ccda076b2a8e5194a1d4bde96bcb44808ccb75ecca33b5669102",
+#    strip_prefix = "bazel-rules-0.5.0",
+#    urls = [
+#        "https://github.com/masmovil/bazel-rules/archive/refs/tags/v0.5.0.tar.gz",
+#    ],
+#)
+
+local_repository(
     name = "com_github_masmovil_bazel_rules",
-    sha256 = "9c8ac4c60da1ccda076b2a8e5194a1d4bde96bcb44808ccb75ecca33b5669102",
-    strip_prefix = "bazel-rules-0.5.0",
-    urls = [
-        "https://github.com/masmovil/bazel-rules/archive/refs/tags/v0.5.0.tar.gz",
-    ],
+    path = "/Users/allanc/src/rules_helm",
 )
 
 # Loading phase -- I tend to put this here when I can to keep the stuff above somewhat ordered
@@ -28,29 +33,3 @@ aspect_bazel_lib_dependencies()
 load("@com_github_masmovil_bazel_rules//repositories:repositories.bzl", masmovil_repositories = "repositories")
 
 masmovil_repositories()
-
-http_archive(
-    name = "age_darwin_amd64",
-    build_file_content = "\n".join([
-        """alias(name="age", actual="//:age/age", visibility = ["//visibility:public"])""",
-        """alias(name="age-keygen", actual="//:age/age-keygen", visibility = ["//visibility:public"])""",
-        "",  # readability during debug
-    ]),
-    sha256 = "81bdfa27906288b1b0d1952202a34c8020da9b01008761ca91100c87d416227c",
-    urls = [
-        "https://github.com/FiloSottile/age/releases/download/v1.1.1/age-v1.1.1-darwin-amd64.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "age_linux_amd64",
-    build_file_content = "\n".join([
-        """alias(name="age", actual="//:age/age", visibility = ["//visibility:public"])""",
-        """alias(name="age-keygen", actual="//:age/age-keygen", visibility = ["//visibility:public"])""",
-        "",  # readability during debug
-    ]),
-    sha256 = "cf16cbb108fc56e2064b00ba2b65d9fb1b8d7002ca5e38260ee1cc34f6aaa8f9",
-    urls = [
-        "https://github.com/FiloSottile/age/releases/download/v1.1.1/age-v1.1.1-linux-amd64.tar.gz",
-    ],
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,7 @@
 workspace(name = "bazel-example-sops-age")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "aspect_bazel_lib",
@@ -18,10 +19,15 @@ http_archive(
 #        "https://github.com/masmovil/bazel-rules/archive/refs/tags/v0.5.0.tar.gz",
 #    ],
 #)
-
-local_repository(
+#
+#local_repository(
+#    name = "com_github_masmovil_bazel_rules",
+#    path = "/Users/allanc/src/rules_helm",
+#)
+git_repository(
     name = "com_github_masmovil_bazel_rules",
-    path = "/Users/allanc/src/rules_helm",
+    branch = "feature/enable-sops-with-age",
+    remote = "https://github.com/chickenandpork/rules_helm.git",
 )
 
 # Loading phase -- I tend to put this here when I can to keep the stuff above somewhat ordered

--- a/age/BUILD.bazel
+++ b/age/BUILD.bazel
@@ -30,6 +30,7 @@ sops_decrypt_file(
 # This End-to-End test is an encrypt/decrypt/diff-check using the generated key `:genkey`.
 diff_test(
     name = "e2e",
+    size = "small",
     failure_message = "decrypted config did not match initial plaintext",
     file1 = "//age:gendata",
     file2 = ":dec",


### PR DESCRIPTION
This PR is optimistic that we can all play together in one sandbox rather than in many, many smaller disjoint sandboxes.

This PR swaps over to use a (hopefully) merged PR to the `masmovil` ruleset (`feature/enable-sops-with-age`) that adds the `age` toolchain to the `masmovil` ruleset.

It's easy enough to simply add another rules_* that defines the age toolset, but due to the use of MasMovil's rules, I'd rather consolidate there especially since it adds no additional dependency and only energizes that `http_archive` if needed.